### PR TITLE
Fix stubbed joystick library syntax

### DIFF
--- a/public/nipplejs.min.js
+++ b/public/nipplejs.min.js
@@ -1,3 +1,1 @@
-(function(){
-  window.nipplejs={create:function(){return{on:function(){},remove:function(){}}};};
-})();
+(function(){window.nipplejs={create:function(){return{on:function(){},remove:function(){}}}};})();


### PR DESCRIPTION
## Summary
- fix syntax error in `public/nipplejs.min.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68457dc6a950832c85e6d9fe5106d9ad