### PR TITLE
Add basic 3D rendering and joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Medieval Survival Demo
 
-This small demo uses Node, Express and Socket.io with Three.js. Buildings,
-monsters and players are rendered as simple 3D meshes. Their relative size is
-scaled so buildings are largest, monsters are larger than the players, and the
-players are the smallest.
+This small demo uses Node, Express and Socket.io with a minimal in-browser 3D
+engine. Buildings, monsters and players are rendered as simple meshes and their
+relative size is scaled so buildings are largest, monsters are larger than the
+players and the players are the smallest. A virtual joystick is provided in the
+bottom left corner for movement.
 
 ## Running the game
 

--- a/public/nipplejs.min.js
+++ b/public/nipplejs.min.js
@@ -1,1 +1,51 @@
-(function(){window.nipplejs={create:function(){return{on:function(){},remove:function(){}}}};})();
+(function(){
+  function Joystick(opts){
+    var zone = opts.zone;
+    var base = document.createElement('div');
+    var stick = document.createElement('div');
+    base.style.position='absolute';
+    base.style.width='100px';
+    base.style.height='100px';
+    base.style.borderRadius='50%';
+    base.style.background='rgba(255,255,255,0.3)';
+    base.style.left=opts.position && opts.position.left || '0px';
+    base.style.bottom=opts.position && opts.position.bottom || '0px';
+    stick.style.position='absolute';
+    stick.style.width='60px';
+    stick.style.height='60px';
+    stick.style.left='20px';
+    stick.style.top='20px';
+    stick.style.borderRadius='50%';
+    stick.style.background=opts.color||'white';
+    base.appendChild(stick);
+    zone.appendChild(base);
+
+    var active=false,startX=0,startY=0,callbacks={move:[],end:[]};
+    function emit(name,data){callbacks[name].forEach(function(fn){fn({},data);});}
+    base.addEventListener('pointerdown',function(e){
+      active=true;startX=e.clientX;startY=e.clientY;
+      e.preventDefault();
+    });
+    window.addEventListener('pointermove',function(e){
+      if(!active) return;
+      var dx=e.clientX-startX,dy=e.clientY-startY;
+      var dist=Math.sqrt(dx*dx+dy*dy);
+      var rad=Math.atan2(dy,dx);
+      var limited=Math.min(dist,40);
+      stick.style.transform='translate('+ (limited*Math.cos(rad))+'px,'+(limited*Math.sin(rad))+'px)';
+      emit('move',{angle:{radian:rad}});
+    });
+    window.addEventListener('pointerup',function(){
+      if(active){
+        active=false;
+        stick.style.transform='translate(0,0)';
+        emit('end');
+      }
+    });
+    this.on=function(name,fn){if(callbacks[name])callbacks[name].push(fn);};
+    this.remove=function(){zone.removeChild(base);};
+  }
+
+  window.nipplejs={create:function(opts){return new Joystick(opts);}};
+})();
+

--- a/public/style.css
+++ b/public/style.css
@@ -3,6 +3,7 @@ body {
   overflow: hidden;
   font-family: sans-serif;
   background: #c2b280;
+  touch-action: none;
 }
 #inventory {
   position: absolute;

--- a/public/three.min.js
+++ b/public/three.min.js
@@ -1,17 +1,120 @@
 (function(){
-  function noop(){}
-  function Color(hex){this.value=hex;this.set=hex=>{this.value=hex};this.setHex=this.set;}
-  function Scene(){this.children=[];this.background=null;this.add=function(o){this.children.push(o);};}
-  function PerspectiveCamera(){this.position={x:0,y:0,z:0,set:function(x,y,z){this.x=x;this.y=y;this.z=z;}};this.aspect=1;this.updateProjectionMatrix=noop;this.lookAt=noop;}
-  function WebGLRenderer(opts){this.domElement=document.createElement('canvas');this.setSize=noop;this.render=noop;}
-  function HemisphereLight(){this.position={set:noop};}
-  function PlaneGeometry(){}
-  function MeshLambertMaterial(opts){this.color={setHex:noop};}
-  function Mesh(geom,mat){this.geometry=geom;this.material=mat||{};this.position={x:0,y:0,z:0,set:function(x,y,z){this.x=x;this.y=y;this.z=z;}};this.rotation={x:0,y:0,z:0};this.userData={};}
-  function Vector2(){this.x=0;this.y=0;}
-  function Raycaster(){this.setFromCamera=noop;this.intersectObjects=function(){return[];};}
-  function BoxGeometry(){}
-  function MeshStandardMaterial(opts){this.color={setHex:noop};}
-  function SphereGeometry(){}
-  window.THREE={Scene:Scene,Color:Color,PerspectiveCamera:PerspectiveCamera,WebGLRenderer:WebGLRenderer,HemisphereLight:HemisphereLight,PlaneGeometry:PlaneGeometry,MeshLambertMaterial:MeshLambertMaterial,Mesh:Mesh,Vector2:Vector2,Raycaster:Raycaster,BoxGeometry:BoxGeometry,MeshStandardMaterial:MeshStandardMaterial,SphereGeometry:SphereGeometry};
+  function Color(hex){
+    this.value = hex || 0;
+    this.set = hex=>{this.value = hex;};
+    this.setHex = this.set;
+  }
+
+  function Scene(){
+    this.children = [];
+    this.background = new Color(0x000000);
+  }
+  Scene.prototype.add = function(o){
+    this.children.push(o);
+  };
+
+  function PerspectiveCamera(){
+    this.position = {x:0,y:0,z:0,set:function(x,y,z){this.x=x;this.y=y;this.z=z;}};
+    this.aspect = 1;
+  }
+  PerspectiveCamera.prototype.updateProjectionMatrix = function(){};
+  PerspectiveCamera.prototype.lookAt = function(){};
+
+  function MeshLambertMaterial(opts){
+    this.color = new Color((opts&&opts.color)||0xffffff);
+  }
+
+  function MeshStandardMaterial(opts){
+    this.color = new Color((opts&&opts.color)||0xffffff);
+  }
+
+  function PlaneGeometry(w,h){
+    this.width = w; this.height = h;
+  }
+
+  function BoxGeometry(w,h,d){
+    this.width = w; this.height = h; this.depth = d;
+  }
+
+  function SphereGeometry(r){
+    this.radius = r;
+  }
+
+  function Mesh(geom,mat){
+    this.geometry = geom;
+    this.material = mat||{};
+    this.position = {x:0,y:0,z:0,set:function(x,y,z){this.x=x;this.y=y;this.z=z;}};
+    this.rotation = {x:0,y:0,z:0};
+    this.userData = {};
+  }
+
+  function Vector2(){ this.x=0; this.y=0; }
+
+  var currentRenderer = null;
+
+  function project(pos,camera,w,h){
+    var dx = pos.x - camera.position.x;
+    var dy = pos.y - camera.position.y;
+    var dz = pos.z - camera.position.z;
+    var isoX = (dx - dz) * 0.5;
+    var isoY = (dx + dz) * 0.25 - dy;
+    return {x: isoX + w/2, y: isoY + h/2};
+  }
+
+  function WebGLRenderer(){
+    this.domElement = document.createElement('canvas');
+    this.ctx = this.domElement.getContext('2d');
+    currentRenderer = this;
+  }
+  WebGLRenderer.prototype.setSize = function(w,h){
+    this.domElement.width = w; this.domElement.height = h;
+  };
+  WebGLRenderer.prototype.render = function(scene,camera){
+    var ctx = this.ctx;
+    var w = this.domElement.width; var h = this.domElement.height;
+    ctx.fillStyle = '#'+scene.background.value.toString(16).padStart(6,'0');
+    ctx.fillRect(0,0,w,h);
+    var objs = scene.children.slice().sort(function(a,b){return b.position.z-a.position.z;});
+    objs.forEach(function(o){ drawObj(ctx,o,camera,w,h); });
+  };
+
+  function drawObj(ctx,o,camera,w,h){
+    var p = project(o.position,camera,w,h);
+    ctx.fillStyle = '#'+o.material.color.value.toString(16).padStart(6,'0');
+    if(o.geometry instanceof BoxGeometry){
+      var size = (o.geometry.width+o.geometry.depth)/2;
+      ctx.fillRect(p.x-size/2,p.y-o.geometry.height,p.x+size/2-(p.x-size/2),o.geometry.height);
+    }else if(o.geometry instanceof SphereGeometry){
+      ctx.beginPath();
+      ctx.arc(p.x,p.y-o.geometry.radius,o.geometry.radius,0,Math.PI*2); ctx.fill();
+    }else if(o.geometry instanceof PlaneGeometry){
+      ctx.fillRect(0,0,w,h);
+    }
+  }
+
+  function Raycaster(){
+    this.mx=0; this.my=0; this.camera=null;
+  }
+  Raycaster.prototype.setFromCamera = function(mouse,camera){
+    this.mx = mouse.x; this.my = mouse.y; this.camera = camera;
+  };
+  Raycaster.prototype.intersectObjects = function(objs){
+    var w=currentRenderer.domElement.width, h=currentRenderer.domElement.height;
+    var sx=(this.mx+1)*w/2, sy=(-this.my+1)*h/2; var hits=[];
+    objs.forEach(function(o){
+      var p=project(o.position, this.camera,w,h); var r=20;
+      if(o.geometry instanceof BoxGeometry){ r=(o.geometry.width+o.geometry.depth)/2; }
+      if(o.geometry instanceof SphereGeometry){ r=o.geometry.radius; }
+      if(sx>=p.x-r && sx<=p.x+r && sy>=p.y-r && sy<=p.y+r){ hits.push({object:o}); }
+    },this);
+    return hits;
+  };
+
+  window.THREE={
+    Scene:Scene,Color:Color,PerspectiveCamera:PerspectiveCamera,WebGLRenderer:WebGLRenderer,
+    HemisphereLight:function(){},PlaneGeometry:PlaneGeometry,MeshLambertMaterial:MeshLambertMaterial,
+    Mesh:Mesh,Vector2:Vector2,Raycaster:Raycaster,BoxGeometry:BoxGeometry,
+    MeshStandardMaterial:MeshStandardMaterial,SphereGeometry:SphereGeometry
+  };
 })();
+


### PR DESCRIPTION
## Summary
- implement minimal canvas-based THREE replacement
- implement simple virtual joystick
- enable pointer events in CSS
- update README to mention custom 3D engine and joystick

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684640679848832c92cd6cf64e5982af