### PR TITLE
Serve Three.js from node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ This project is a fresh start for a simple networked 3D game built with Three.js
    ```
 3. Open `http://localhost:3000` in your browser.
 
+The server exposes Three.js from `node_modules` at `/vendor/three.module.js`, so the client can load it without relying on a CDN or bundler.
+
 This rewrite contains only the minimal features: a basic scene and networked player cubes. More functionality can be built on top of this foundation.

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,4 +1,5 @@
-import * as THREE from 'three';
+// Load Three.js served from node_modules without using a bundler
+import * as THREE from '/vendor/three.module.js';
 import io from '/socket.io/socket.io.js';
 
 const socket = io();

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,9 @@ const io = new Server(httpServer, {
 });
 
 app.use(express.static(path.join(__dirname, '..', 'public')));
+app.use('/vendor', express.static(
+  path.join(__dirname, '..', 'node_modules', 'three', 'build')
+));
 
 const players = new Map();
 


### PR DESCRIPTION
## Summary
- expose `node_modules/three/build` as `/vendor`
- update README to mention `/vendor/three.module.js`
- adjust comment in client code
- remove unused vendor copy of `three.module.js`

## Testing
- `npm test` *(fails: Missing script `test`)*


------
https://chatgpt.com/codex/tasks/task_e_6846b544a9a4832cacb8bb7c2dcba5c3