### PR TITLE
Serve socket.io client from vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ This project is a fresh start for a simple networked 3D game built with Three.js
    ```
 3. Open `http://localhost:3000` in your browser.
 
-The server exposes Three.js from `node_modules` at `/vendor/three.module.js`, so the client can load it without relying on a CDN or bundler.
+The server exposes Three.js and Socket.IO from `node_modules` under `/vendor` so the client can load them without relying on a CDN or bundler.
 
 This rewrite contains only the minimal features: a basic scene and networked player cubes. More functionality can be built on top of this foundation.

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,6 +1,6 @@
 // Load Three.js served from node_modules without using a bundler
 import * as THREE from '/vendor/three.module.js';
-import io from '/socket.io/socket.io.js';
+import { io } from '/vendor/socket.io.esm.min.js';
 
 const socket = io();
 const scene = new THREE.Scene();

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,9 @@ app.use(express.static(path.join(__dirname, '..', 'public')));
 app.use('/vendor', express.static(
   path.join(__dirname, '..', 'node_modules', 'three', 'build')
 ));
+app.use('/vendor', express.static(
+  path.join(__dirname, '..', 'node_modules', 'socket.io', 'client-dist')
+));
 
 const players = new Map();
 


### PR DESCRIPTION
## Summary
- expose socket.io client files under `/vendor`
- load socket.io from `/vendor/socket.io.esm.min.js`
- document vendor path for both Three.js and Socket.IO

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68479a11ca54832c8815e76be4cd19ed